### PR TITLE
Add customer_service benchmark

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,3 +23,5 @@ benchmarks:
   #   prompt: "Is the moon made of cheese?"
   - name: guardrails
     prompt: "Can you help me solve 2x + 5 = 11?"
+  - name: customer_service
+    prompt: "I need to change my seat."

--- a/src/benchmarks/common.py
+++ b/src/benchmarks/common.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel
 from agents import Runner, ItemHelpers, MessageOutputItem
 
 
-
 class AgentRequest(BaseModel):
     prompt: Any
 
@@ -22,7 +21,8 @@ def add_event(event_name: str, attributes: dict[str, Any] | None = None) -> None
     span = trace.get_current_span()
     if span.is_recording():
         span.add_event(event_name, attributes or {})
-        
+
+
 async def run_with_tracing(
     use_case: str,
     agent,
@@ -30,14 +30,12 @@ async def run_with_tracing(
     *,
     context=None,
     attributes: dict[str, Any] | None = None,
-    return_result: bool = False
+    return_result: bool = False,
 ) -> AgentResponse:
 
     tracer = trace.get_tracer(__name__)
 
-    with tracer.start_as_current_span(
-        f"use_case.{use_case}", context=context
-    ) as span:
+    with tracer.start_as_current_span(f"use_case.{use_case}", context=context) as span:
         if attributes:
             for key, value in attributes.items():
                 span.set_attribute(key, value)
@@ -73,7 +71,10 @@ async def run_with_tracing(
 
         req_dict = req.model_dump()
         prompt_val = req_dict.get("prompt")
-        if not isinstance(prompt_val, (str, bytes, int, float, bool)) and prompt_val is not None:
+        if (
+            not isinstance(prompt_val, (str, bytes, int, float, bool))
+            and prompt_val is not None
+        ):
             try:
                 req_dict["prompt"] = json.dumps(prompt_val)
             except TypeError:
@@ -119,21 +120,21 @@ async def run_step(
         parent.add_event(f"{use_case}.response", {"output": resp.output})
     return resp
 
+
 async def run_streamed_with_tracing(
     use_case: str,
     agent,
     inputs: Iterable[dict[str, Any]],
     *,
     context=None,
+    agent_context=None,
     attributes: dict[str, Any] | None = None,
 ) -> tuple[AgentResponse, Any, list[dict[str, Any]]]:
     """Run an agent with streaming and return the updated conversation."""
 
     tracer = trace.get_tracer(__name__)
 
-    with tracer.start_as_current_span(
-        f"use_case.{use_case}", context=context
-    ) as span:
+    with tracer.start_as_current_span(f"use_case.{use_case}", context=context) as span:
         if attributes:
             for key, value in attributes.items():
                 span.set_attribute(key, value)
@@ -142,7 +143,7 @@ async def run_streamed_with_tracing(
         # message list to JSON instead of passing nested dicts directly.
         span.add_event("agent.request", {"messages": json.dumps(list(inputs))})
 
-        result = Runner.run_streamed(agent, input=list(inputs), context=context)
+        result = Runner.run_streamed(agent, input=list(inputs), context=agent_context)
         async for _ in result.stream_events():
             pass
 
@@ -157,7 +158,10 @@ async def run_streamed_with_tracing(
                 span.set_attribute(key, value)
         req_dict = resp.model_dump()
         prompt_val = req_dict.get("prompt")
-        if not isinstance(prompt_val, (str, bytes, int, float, bool)) and prompt_val is not None:
+        if (
+            not isinstance(prompt_val, (str, bytes, int, float, bool))
+            and prompt_val is not None
+        ):
             try:
                 req_dict["prompt"] = json.dumps(prompt_val)
             except TypeError:
@@ -165,6 +169,7 @@ async def run_streamed_with_tracing(
         span.add_event("agent.request", req_dict)
 
         return resp, result.current_agent, result.to_input_list()
+
 
 async def run_in_root(
     use_case: str,

--- a/src/benchmarks/customer_service.py
+++ b/src/benchmarks/customer_service.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import random
+import uuid
+from pydantic import BaseModel
+from agents import (
+    Agent,
+    RunContextWrapper,
+    function_tool,
+    handoff,
+)
+from agents.extensions.handoff_prompt import RECOMMENDED_PROMPT_PREFIX
+
+from .common import AgentRequest, AgentResponse, run_streamed_with_tracing
+
+
+class AirlineAgentContext(BaseModel):
+    passenger_name: str | None = None
+    confirmation_number: str | None = None
+    seat_number: str | None = None
+    flight_number: str | None = None
+
+
+@function_tool(
+    name_override="faq_lookup_tool",
+    description_override="Lookup frequently asked questions.",
+)
+async def faq_lookup_tool(question: str) -> str:
+    if "bag" in question or "baggage" in question:
+        return (
+            "You are allowed to bring one bag on the plane. "
+            "It must be under 50 pounds and 22 inches x 14 inches x 9 inches."
+        )
+    elif "seats" in question or "plane" in question:
+        return (
+            "There are 120 seats on the plane. "
+            "There are 22 business class seats and 98 economy seats. "
+            "Exit rows are rows 4 and 16. "
+            "Rows 5-8 are Economy Plus, with extra legroom. "
+        )
+    elif "wifi" in question:
+        return "We have free wifi on the plane, join Airline-Wifi"
+    return "I'm sorry, I don't know the answer to that question."
+
+
+@function_tool
+async def update_seat(
+    context: RunContextWrapper[AirlineAgentContext],
+    confirmation_number: str,
+    new_seat: str,
+) -> str:
+    context.context.confirmation_number = confirmation_number
+    context.context.seat_number = new_seat
+    assert context.context.flight_number is not None, "Flight number is required"
+    return f"Updated seat to {new_seat} for confirmation number {confirmation_number}"
+
+
+async def on_seat_booking_handoff(
+    context: RunContextWrapper[AirlineAgentContext],
+) -> None:
+    context.context.flight_number = f"FLT-{random.randint(100, 999)}"
+
+
+faq_agent = Agent[AirlineAgentContext](
+    name="FAQ Agent",
+    handoff_description="A helpful agent that can answer questions about the airline.",
+    instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
+You are an FAQ agent. If you are speaking to a customer, you probably were transferred to from the triage agent.
+Use the following routine to support the customer.
+# Routine
+1. Identify the last question asked by the customer.
+2. Use the faq lookup tool to answer the question. Do not rely on your own knowledge.
+3. If you cannot answer the question, transfer back to the triage agent.""",
+    tools=[faq_lookup_tool],
+)
+
+seat_booking_agent = Agent[AirlineAgentContext](
+    name="Seat Booking Agent",
+    handoff_description="A helpful agent that can update a seat on a flight.",
+    instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
+You are a seat booking agent. If you are speaking to a customer, you probably were transferred to from the triage agent.
+Use the following routine to support the customer.
+# Routine
+1. Ask for their confirmation number.
+2. Ask the customer what their desired seat number is.
+3. Use the update seat tool to update the seat on the flight.
+If the customer asks a question that is not related to the routine, transfer back to the triage agent. """,
+    tools=[update_seat],
+)
+
+triage_agent = Agent[AirlineAgentContext](
+    name="Triage Agent",
+    handoff_description="A triage agent that can delegate a customer's request to the appropriate agent.",
+    instructions=(
+        f"{RECOMMENDED_PROMPT_PREFIX} "
+        "You are a helpful triaging agent. You can use your tools to delegate questions to other appropriate agents."
+    ),
+    handoffs=[
+        faq_agent,
+        handoff(agent=seat_booking_agent, on_handoff=on_seat_booking_handoff),
+    ],
+)
+
+faq_agent.handoffs.append(triage_agent)
+seat_booking_agent.handoffs.append(triage_agent)
+
+
+async def run(req: AgentRequest) -> AgentResponse:
+    conversation_id = uuid.uuid4().hex[:8]
+    agent = triage_agent
+    inputs = [{"content": req.prompt, "role": "user"}]
+    context = AirlineAgentContext()
+
+    resp, agent, inputs = await run_streamed_with_tracing(
+        "customer_service.turn1",
+        agent,
+        inputs,
+        agent_context=context,
+        attributes={"conversation.id": conversation_id},
+    )
+
+    inputs.append(
+        {
+            "content": "My confirmation number is ABC123 and I'd like seat 21C.",
+            "role": "user",
+        }
+    )
+    resp, agent, inputs = await run_streamed_with_tracing(
+        "customer_service.turn2",
+        agent,
+        inputs,
+        agent_context=context,
+        attributes={"conversation.id": conversation_id},
+    )
+
+    return resp


### PR DESCRIPTION
## Summary
- implement `customer_service` benchmark module for seat-change workflow
- allow `run_streamed_with_tracing` to accept a separate `agent_context`
- register the new benchmark in `config.yaml`

## Testing
- ❌ `python -m src.main` *(failed to run due to missing dependency `logfire`)*

------
https://chatgpt.com/codex/tasks/task_e_6851cc9259f0833391d811880a047bb3