### PR TITLE
Add built-in tracing example

### DIFF
--- a/src/builtin_tracing/README.md
+++ b/src/builtin_tracing/README.md
@@ -1,0 +1,15 @@
+# Built-in tracing example
+
+This directory shows how to run the OpenAI Agents SDK examples using Logfire's
+built-in instrumentation.
+
+The script `hello_world_with_logfire.py` runs the SDK's `basic/hello_world`
+example while automatically exporting traces to Logfire.
+
+To run the script:
+
+```bash
+export OPENAI_API_KEY=...
+export LOGFIRE_TOKEN=...
+python -m src.builtin_tracing.hello_world_with_logfire
+```

--- a/src/builtin_tracing/hello_world_with_logfire.py
+++ b/src/builtin_tracing/hello_world_with_logfire.py
@@ -1,0 +1,34 @@
+import asyncio
+import os
+import logfire
+from pathlib import Path
+import sys
+
+"""Run the Agents SDK hello world example with Logfire tracing."""
+
+# Ensure the submodule is on the import path
+submodule_path = Path(__file__).resolve().parents[1] / "openai_agents" / "src"
+sys.path.append(str(submodule_path))
+
+from agents import Agent, Runner
+
+
+async def main() -> None:
+    logfire.configure(token=os.getenv("LOGFIRE_TOKEN"))
+    # Automatically convert Agents SDK traces to Logfire spans.
+    logfire.instrument_openai_agents()
+
+    if not os.getenv("OPENAI_API_KEY"):
+        raise RuntimeError("Please set OPENAI_API_KEY")
+
+    agent = Agent(
+        name="Assistant",
+        instructions="You only respond in haikus.",
+    )
+
+    result = await Runner.run(agent, "Tell me about recursion in programming.")
+    print(result.final_output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a small example showing how to run an Agents SDK workflow with Logfire's tracing integration
- document usage of `hello_world_with_logfire.py`

## Testing
- `python -m src.builtin_tracing.hello_world_with_logfire` *(fails: ModuleNotFoundError or network)*

------
https://chatgpt.com/codex/tasks/task_e_6851d863536483338399d5761c9e7fb9