### PR TITLE
Add GAIA manager and assistant agents

### DIFF
--- a/GAIA_agent_design/agents_lib/__init__.py
+++ b/GAIA_agent_design/agents_lib/__init__.py
@@ -1,5 +1,7 @@
 from .file_router import FileRouterAgent
 from .knowledge_agent import KnowledgeAgent
+from .knowledge_assistant import KnowledgeAssistantAgent
+from .synthesis_agent import SynthesisAgent
 from .verifier_agent import VerifierAgent
 
 from .processors.text_processor import TextProcessorAgent
@@ -12,6 +14,8 @@ from .processors.audio_stt_agent import AudioSTTAgent
 __all__ = [
     "FileRouterAgent",
     "KnowledgeAgent",
+    "KnowledgeAssistantAgent",
+    "SynthesisAgent",
     "VerifierAgent",
     "TextProcessorAgent",
     "DocxProcessorAgent",

--- a/GAIA_agent_design/agents_lib/coordinator.py
+++ b/GAIA_agent_design/agents_lib/coordinator.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Sequence
+
+from agents import Runner, ItemHelpers, trace
+from agents.mcp import MCPServerStdio
+
+from .file_router import FileRouterAgent
+from .knowledge_assistant import KnowledgeAssistantAgent
+from .synthesis_agent import SynthesisAgent
+from .verifier_agent import VerifierAgent
+from .processors.text_processor import TextProcessorAgent
+from .processors.docx_processor import DocxProcessorAgent
+from .processors.excel_processor import ExcelProcessorAgent
+from .processors.pdf_processor import PDFProcessorAgent
+from .processors.image_ocr_agent import ImageOCRAgent
+from .processors.audio_stt_agent import AudioSTTAgent
+
+PROCESSORS = {
+    "text": TextProcessorAgent(),
+    "docx": DocxProcessorAgent(),
+    "excel": ExcelProcessorAgent(),
+    "pdf": PDFProcessorAgent(),
+    "image": ImageOCRAgent(),
+    "audio": AudioSTTAgent(),
+}
+
+
+def _choose_processor(mime: str):
+    if mime.startswith("text/") or "json" in mime or "python" in mime:
+        return PROCESSORS["text"]
+    if "word" in mime:
+        return PROCESSORS["docx"]
+    if "excel" in mime or "spreadsheet" in mime:
+        return PROCESSORS["excel"]
+    if "pdf" in mime:
+        return PROCESSORS["pdf"]
+    if mime.startswith("image/"):
+        return PROCESSORS["image"]
+    if mime.startswith("audio/"):
+        return PROCESSORS["audio"]
+    return PROCESSORS["text"]
+
+
+class GAIAManager:
+    def __init__(self, media_dir: Path) -> None:
+        self.media_dir = media_dir
+        self.file_router = FileRouterAgent(media_dir)
+        self.assistants = [KnowledgeAssistantAgent() for _ in range(3)]
+        self.synth_agents = [SynthesisAgent() for _ in range(3)]
+        self.verifier = VerifierAgent()
+
+    async def run(self, jsonl_path: str, out_path: str) -> None:
+        async with MCPServerStdio(
+            name="GAIA Filesystem",
+            params={
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", str(self.media_dir)],
+            },
+        ):
+            with open(jsonl_path) as src, open(out_path, "w") as dst:
+                for line in src:
+                    task = json.loads(line)
+                    tid = task["task_id"]
+                    question = task["Question"]
+                    span_name = f"GAIA Question {tid}"
+                    with trace(span_name):
+                        context = await self._get_context(tid)
+                        answer, reasoning = await self._answer(question, context)
+                        verified = await self.verifier.verify(answer)
+                    out = {
+                        "task_id": tid,
+                        "model_answer": answer,
+                        "reasoning_trace": reasoning,
+                        "verified": verified,
+                    }
+                    dst.write(json.dumps(out, ensure_ascii=False) + "\n")
+
+    async def _get_context(self, task_id: str) -> str:
+        raw, mime = self.file_router.fetch(task_id)
+        if raw is None or mime is None:
+            return ""
+        processor = _choose_processor(mime)
+        text = processor.process(raw, mime)
+        return text[:30000]
+
+    async def _answer(self, question: str, context: str) -> tuple[str, str]:
+        prompt = f"Question: {question}\n\nContext:\n{context}"
+        # run assistants in parallel
+        assist_tasks = [Runner.run(a, prompt) for a in self.assistants]
+        assist_results = await asyncio.gather(*assist_tasks)
+        notes = "\n".join(res.final_output for res in assist_results)
+
+        # synthesize multiple candidate answers
+        synth_tasks = [a.synthesize(question, notes) for a in self.synth_agents]
+        candidates = await asyncio.gather(*synth_tasks)
+        answers, reasonings = zip(*candidates)
+
+        # choose best using verifier
+        best_index = await self.verifier.choose_best(list(answers))
+        return answers[best_index], reasonings[best_index]

--- a/GAIA_agent_design/agents_lib/knowledge_assistant.py
+++ b/GAIA_agent_design/agents_lib/knowledge_assistant.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from agents import Agent
+
+from .tools.web_search_tool import get_web_search_tool
+from .tools.file_search_tool import get_file_search_tool
+
+ASSISTANT_PROMPT = """
+You are a research assistant helping to answer GAIA benchmark questions.
+Use the available tools to search the web or local files for facts related to the
+question and context provided. Summarize your findings as short bullet points.
+Do not attempt to produce the final answer.
+""".strip()
+
+
+class KnowledgeAssistantAgent(Agent):
+    def __init__(self) -> None:
+        tools = [get_web_search_tool()]
+        fs = get_file_search_tool()
+        if fs is not None:
+            tools.append(fs)
+        super().__init__(name="KnowledgeAssistant", instructions=ASSISTANT_PROMPT, tools=tools)

--- a/GAIA_agent_design/agents_lib/synthesis_agent.py
+++ b/GAIA_agent_design/agents_lib/synthesis_agent.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from agents import Agent, Runner, ItemHelpers
+
+SYSTEM_PROMPT = """
+You are a general AI assistant. I will ask you a question. \
+Report your thoughts, and finish your answer with the following template:
+
+FINAL ANSWER: [YOUR FINAL ANSWER]
+
+YOUR FINAL ANSWER should be a number OR as few words as possible OR \
+a comma separated list of numbers and/or strings. If you are asked for \
+a number, don't use commas or units (like $ or %). If you are asked for \
+a string, don't use articles or abbreviations, and write digits in plain text.
+""".strip()
+
+
+class SynthesisAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(name="SynthesisAgent", instructions=SYSTEM_PROMPT)
+
+    async def synthesize(self, question: str, notes: str) -> tuple[str, str]:
+        prompt = f"Question: {question}\n\nResearch notes:\n{notes}"
+        result = await Runner.run(self, prompt)
+        text = "\n".join(ItemHelpers.text_message_outputs(result.new_items)).strip()
+        if "FINAL ANSWER:" in text:
+            reasoning, final = text.rsplit("FINAL ANSWER:", 1)
+            return final.strip(), reasoning.strip()
+        return text, text

--- a/GAIA_agent_design/agents_lib/verifier_agent.py
+++ b/GAIA_agent_design/agents_lib/verifier_agent.py
@@ -31,3 +31,19 @@ class VerifierAgent(Agent):
         )
         result = await Runner.run(self, prompt)
         return f"Verified: {result.final_output.strip()}"
+
+    async def choose_best(self, answers: list[str]) -> int:
+        """Given multiple candidate answers, pick the best one.
+
+        Returns the index of the preferred answer.
+        """
+        joined = "\n".join(f"Option {i+1}: {a}" for i, a in enumerate(answers))
+        prompt = (
+            "Evaluate the following candidate answers using web search and "
+            "respond with the number of the best option.\n" + joined
+        )
+        result = await Runner.run(self, prompt)
+        try:
+            return int(result.final_output.strip()) - 1
+        except Exception:
+            return 0

--- a/GAIA_agent_design/run_gaia_manager.py
+++ b/GAIA_agent_design/run_gaia_manager.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import logfire
+
+from agents_lib.coordinator import GAIAManager
+
+
+logfire.configure()
+logfire.instrument_httpx()
+logfire.instrument_openai_agents()
+
+
+async def main(jsonl_path: str, out_path: str) -> None:
+    media_dir = Path("GAIA_agent_design/gaia_media").resolve()
+    manager = GAIAManager(media_dir)
+    await manager.run(jsonl_path, out_path)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python run_gaia_manager.py metadata.jsonl submission.jsonl")
+        raise SystemExit(1)
+    asyncio.run(main(sys.argv[1], sys.argv[2]))


### PR DESCRIPTION
## Summary
- create KnowledgeAssistantAgent and SynthesisAgent for multi-step research
- add GAIAManager orchestrator running assistants in parallel
- extend VerifierAgent with choose_best helper
- expose new classes in package init
- provide `run_gaia_manager.py` entry point

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855f3c098088333bccc2efd02e510d9