### PR TITLE
Enable GPT-4o vision processors

### DIFF
--- a/GAIA_agent_design/AGENT.MD
+++ b/GAIA_agent_design/AGENT.MD
@@ -22,11 +22,11 @@ CoordinatorAgent
     │    ├─ TextProcessorAgent  # .txt, .json, .py
     │    ├─ DocxProcessorAgent  # .docx          (python-docx)
     │    ├─ ExcelProcessorAgent # .xls/.xlsx     (pandas)
-    │    ├─ PDFProcessorAgent   # .pdf           (pdfplumber/tika)
+    │    ├─ PDFVisionAgent      # .pdf           (GPT-4o file vision)
     │    ├─ PPTXProcessorAgent  # .pptx          (python-pptx)
     │    ├─ PDBProcessorAgent   # .pdb           (biopython)
     │    ├─ ZipProcessorAgent   # .zip           (extract + text)
-    │    ├─ ImageOCRAgent       # .png/.jpg      (Tesseract / vision API)
+    │    ├─ ImageVisionAgent    # .png/.jpg      (GPT-4o vision)
     │    └─ AudioSTTAgent       # .wav/.mp3      (Whisper / cloud STT)
     ├─ KnowledgeAgent           # QA: Plan→Act→Reflect with search/file tools
     ├─ WriteAgent               # Formats answer and reasoning into GAIA-spec JSONL
@@ -114,3 +114,14 @@ agents/tools/
 * **openai-agents-python/examples/voice/static**: audio STT pipelines
 
 This blueprint will guide incremental implementation, testing, and extension of your GAIA benchmark agent system. langfristig, each component can be refined, prompt‑tuned, and instrumented with LogFire traces for full transparency.
+
+### Media processing pipeline
+
+Media files are handled according to type:
+
+* **Images (PNG/JPEG):** sent directly to GPT‑4o via `ImageVisionAgent` which returns OCR text or a brief description.
+* **PDFs:** uploaded to the vision API with `PDFVisionAgent` so the model can read native text or scanned pages.
+* **Audio:** processed with Whisper in `AudioSTTAgent`.
+* **Other formats:** converted to plain text using the corresponding processor (docx, pptx, spreadsheets, archives, etc.).
+
+The resulting text or summary is then used as context for the planner agent.

--- a/GAIA_agent_design/agents_lib/processors/__init__.py
+++ b/GAIA_agent_design/agents_lib/processors/__init__.py
@@ -3,8 +3,8 @@
 from .text_processor import TextProcessorAgent
 from .docx_processor import DocxProcessorAgent
 from .excel_processor import ExcelProcessorAgent
-from .pdf_processor import PDFProcessorAgent
-from .image_ocr_agent import ImageOCRAgent
+from .pdf_vision_agent import PDFVisionAgent
+from .image_vision_agent import ImageVisionAgent
 from .audio_stt_agent import AudioSTTAgent
 from .pptx_processor import PPTXProcessorAgent
 from .pdb_processor import PDBProcessorAgent
@@ -16,8 +16,8 @@ __all__ = [
     "TextProcessorAgent",
     "DocxProcessorAgent",
     "ExcelProcessorAgent",
-    "PDFProcessorAgent",
-    "ImageOCRAgent",
+    "PDFVisionAgent",
+    "ImageVisionAgent",
     "AudioSTTAgent",
     "PPTXProcessorAgent",
     "PDBProcessorAgent",

--- a/GAIA_agent_design/agents_lib/processors/image_vision_agent.py
+++ b/GAIA_agent_design/agents_lib/processors/image_vision_agent.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from hashlib import sha1
+from typing import Dict
+
+from .vision_utils import process_image_bytes
+
+DEFAULT_PROMPT = "Extract any text from this image. If there is no text, briefly describe the contents."
+
+
+class ImageVisionAgent:
+    """Use GPT-4o vision to analyze images."""
+
+    def __init__(self, prompt: str = DEFAULT_PROMPT) -> None:
+        self.prompt = prompt
+        self._cache: Dict[str, str] = {}
+
+    def process(self, raw: bytes, mime_type: str) -> str:
+        key = sha1(raw).hexdigest()
+        if key in self._cache:
+            return self._cache[key]
+        text = process_image_bytes(raw, self.prompt)
+        self._cache[key] = text
+        return text

--- a/GAIA_agent_design/agents_lib/processors/pdf_vision_agent.py
+++ b/GAIA_agent_design/agents_lib/processors/pdf_vision_agent.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from hashlib import sha1
+from typing import Dict
+
+from .vision_utils import process_pdf_bytes
+
+DEFAULT_PROMPT = "Extract useful text from this PDF or describe its contents."
+
+
+class PDFVisionAgent:
+    """Use GPT-4o vision to read PDFs."""
+
+    def __init__(self, prompt: str = DEFAULT_PROMPT) -> None:
+        self.prompt = prompt
+        self._cache: Dict[str, str] = {}
+
+    def process(self, raw: bytes, mime_type: str) -> str:
+        key = sha1(raw).hexdigest()
+        if key in self._cache:
+            return self._cache[key]
+        text = process_pdf_bytes(raw, self.prompt)
+        self._cache[key] = text
+        return text

--- a/GAIA_agent_design/agents_lib/processors/processor_utils.py
+++ b/GAIA_agent_design/agents_lib/processors/processor_utils.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from .text_processor import TextProcessorAgent
 from .docx_processor import DocxProcessorAgent
 from .excel_processor import ExcelProcessorAgent
-from .pdf_processor import PDFProcessorAgent
-from .image_ocr_agent import ImageOCRAgent
+from .pdf_vision_agent import PDFVisionAgent
+from .image_vision_agent import ImageVisionAgent
 from .audio_stt_agent import AudioSTTAgent
 from .pptx_processor import PPTXProcessorAgent
 from .pdb_processor import PDBProcessorAgent
@@ -15,8 +15,8 @@ PROCESSORS = {
     "text": TextProcessorAgent(),
     "docx": DocxProcessorAgent(),
     "excel": ExcelProcessorAgent(),
-    "pdf": PDFProcessorAgent(),
-    "image": ImageOCRAgent(),
+    "pdf": PDFVisionAgent(),
+    "image": ImageVisionAgent(),
     "audio": AudioSTTAgent(),
     "pptx": PPTXProcessorAgent(),
     "pdb": PDBProcessorAgent(),

--- a/GAIA_agent_design/agents_lib/processors/vision_utils.py
+++ b/GAIA_agent_design/agents_lib/processors/vision_utils.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import base64
+from io import BytesIO
+from typing import Any
+
+import openai
+
+VISION_MODEL = "gpt-4o"
+
+def process_image_bytes(raw: bytes, prompt: str) -> str:
+    """Send an image to the OpenAI vision model and return the text reply."""
+    b64 = base64.b64encode(raw).decode("ascii")
+    result = openai.chat.completions.create(
+        model=VISION_MODEL,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{b64}"},
+                    },
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ],
+    )
+    return result.choices[0].message.content.strip()
+
+def process_pdf_bytes(raw: bytes, prompt: str) -> str:
+    """Send a PDF to the OpenAI vision model via file upload."""
+    file_obj = BytesIO(raw)
+    file = openai.files.create(file=("document.pdf", file_obj), purpose="vision")
+    try:
+        result = openai.chat.completions.create(
+            model=VISION_MODEL,
+            messages=[{"role": "user", "content": [{"type": "text", "text": prompt}]}],
+            file_ids=[file.id],
+        )
+    finally:
+        openai.files.delete(file.id)
+    return result.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- switch GAIA design docs to use ImageVisionAgent and PDFVisionAgent
- implement `ImageVisionAgent` and `PDFVisionAgent`
- add `vision_utils` helper
- update processor utilities to use the new vision agents

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685db6b9f3b48333a8eac0ba14e0e7d5