### PR TITLE
Add sandbox helper

### DIFF
--- a/GAIA_agent_design/agents_lib/tools/__init__.py
+++ b/GAIA_agent_design/agents_lib/tools/__init__.py
@@ -1,0 +1,20 @@
+"""Helper functions for constructing agent tools."""
+
+from .code_interpreter import get_code_interpreter_tool
+from .computer_tool import get_computer_tool, get_local_shell_tool
+from .file_search_tool import get_file_search_tool
+from .hosted_mcp_tool import get_hosted_mcp_tool
+from .image_gen_tool import get_image_generation_tool
+from .web_search_tool import get_web_search_tool
+from .sandbox import run_python
+
+__all__ = [
+    "get_code_interpreter_tool",
+    "get_computer_tool",
+    "get_local_shell_tool",
+    "get_file_search_tool",
+    "get_hosted_mcp_tool",
+    "get_image_generation_tool",
+    "get_web_search_tool",
+    "run_python",
+]

--- a/GAIA_agent_design/agents_lib/tools/sandbox.py
+++ b/GAIA_agent_design/agents_lib/tools/sandbox.py
@@ -1,0 +1,39 @@
+"""Simple sandbox for executing Python code with tracing."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from opentelemetry import trace
+
+
+def run_python(code: str, timeout: int = 30) -> str:
+    """Run a Python code snippet in an isolated temp directory.
+
+    The code is executed in a separate process so that any installed packages
+    or side effects do not leak into the main application. All output is
+    returned as a string. Execution time is limited by ``timeout`` seconds.
+    """
+
+    tracer = trace.get_tracer(__name__)
+
+    with tracer.start_as_current_span("sandbox.run_python") as span:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            script_path = Path(tmpdir) / "snippet.py"
+            script_path.write_text(code)
+
+            result = subprocess.run(
+                [sys.executable, str(script_path)],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+
+            span.set_attribute("exit_code", result.returncode)
+            if result.stderr:
+                span.set_attribute("stderr", result.stderr.strip())
+
+            return result.stdout + result.stderr

--- a/GAIA_agent_design/research_bot/README.md
+++ b/GAIA_agent_design/research_bot/README.md
@@ -31,3 +31,26 @@ If you're building your own research bot, some ideas to add to this are:
 2. Image and file upload: Allow users to attach PDFs or other files, as baseline context for the research.
 3. More planning and thinking: Models often produce better results given more time to think. Improve the planning process to come up with a better plan, and add an evaluation step so that the model can choose to improve its results, search for more stuff, etc.
 4. Code execution: Allow running code, which is useful for data analysis.
+
+## Local sandbox for code execution
+
+When the Code Interpreter tool is unavailable, you can run Python snippets in a
+local sandbox using the helper in `agents_lib.tools.sandbox`. The `run_python`
+function executes the given code in a temporary directory with telemetry spans.
+Example:
+
+```python
+from GAIA_agent_design.agents_lib.tools import run_python
+
+output = run_python("""
+from Bio.PDB import PDBParser
+parser = PDBParser(QUIET=True)
+structure = parser.get_structure('5WB7', '5wb7.pdb')
+first_atom = list(structure.get_atoms())[0]
+print(first_atom.get_coord())
+""")
+print(output)
+```
+
+This keeps the execution isolated and records a `sandbox.run_python` span so it
+appears in your Logfire traces.


### PR DESCRIPTION
## Summary
- document how to run the research bot
- export tool helpers in one place
- provide a simple `run_python` helper that executes code in a temporary sandbox

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685dc5f408248333834aa1cbe9c4551a