### PR TITLE
Fix GAIA manager loops and attachment API

### DIFF
--- a/GAIA_agent_design/agents_lib/processors/docx_processor.py
+++ b/GAIA_agent_design/agents_lib/processors/docx_processor.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from io import BytesIO
 from typing import List
+
+from ..file_router import Attachment
 
 from docx import Document
 
@@ -9,9 +10,9 @@ from docx import Document
 class DocxProcessorAgent:
     """Extract text from .docx files."""
 
-    def process(self, raw: bytes, mime_type: str) -> str:
-        file_like = BytesIO(raw)
-        doc = Document(file_like)
+    def process(self, att: Attachment) -> str:
+        """Extract text from a DOCX file."""
+        doc = Document(att.path)
         texts: List[str] = [p.text for p in doc.paragraphs if p.text]
         for table in doc.tables:
             for row in table.rows:

--- a/GAIA_agent_design/agents_lib/processors/excel_processor.py
+++ b/GAIA_agent_design/agents_lib/processors/excel_processor.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from io import BytesIO
 from typing import List
+
+from ..file_router import Attachment
 
 from openpyxl import load_workbook
 import csv
@@ -11,8 +12,9 @@ import io
 class ExcelProcessorAgent:
     """Convert Excel sheets to CSV-formatted text."""
 
-    def process(self, raw: bytes, mime_type: str) -> str:
-        wb = load_workbook(BytesIO(raw), data_only=False)
+    def process(self, att: Attachment) -> str:
+        """Convert an Excel file to CSV-formatted text."""
+        wb = load_workbook(att.path, data_only=False)
         texts: List[str] = []
         for sheet in wb.worksheets:
             output = io.StringIO()

--- a/GAIA_agent_design/agents_lib/processors/image_ocr_agent.py
+++ b/GAIA_agent_design/agents_lib/processors/image_ocr_agent.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from io import BytesIO
 from typing import Dict
+
+from ..file_router import Attachment
 import base64
 import openai
 
@@ -50,11 +52,11 @@ class ImageOCRAgent:
     def __init__(self) -> None:
         self._cache: Dict[str, str] = {}
 
-    def process(self, raw: bytes, mime_type: str) -> str:
-        key = str(hash(raw))
+    def process(self, att: Attachment) -> str:
+        key = str(hash(att.bytes))
         if key in self._cache:
             return self._cache[key]
-        image = Image.open(BytesIO(raw))
+        image = Image.open(att.path)
         try:
             text = call_vision_api(image)
         except Exception:

--- a/GAIA_agent_design/agents_lib/processors/image_vision_agent.py
+++ b/GAIA_agent_design/agents_lib/processors/image_vision_agent.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from hashlib import sha1
 from typing import Dict
 
+from ..file_router import Attachment
+
 from .vision_utils import process_image_bytes
 
 DEFAULT_PROMPT = "Extract any text from this image and describe all contents in detail."
@@ -15,10 +17,10 @@ class ImageVisionAgent:
         self.prompt = prompt
         self._cache: Dict[str, str] = {}
 
-    def process(self, raw: bytes, mime_type: str) -> str:
-        key = sha1(raw).hexdigest()
+    def process(self, att: Attachment) -> str:
+        key = sha1(att.bytes).hexdigest()
         if key in self._cache:
             return self._cache[key]
-        text = process_image_bytes(raw, self.prompt)
+        text = process_image_bytes(att.bytes, self.prompt)
         self._cache[key] = text
         return text

--- a/GAIA_agent_design/agents_lib/processors/pdb_processor.py
+++ b/GAIA_agent_design/agents_lib/processors/pdb_processor.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-from io import BytesIO
 from Bio.PDB import PDBParser
+
+from ..file_router import Attachment
 
 
 class PDBProcessorAgent:
     """Extract a simple summary from PDB files."""
 
-    def process(self, raw: bytes, mime_type: str) -> str:
+    def process(self, att: Attachment) -> str:
         parser = PDBParser(QUIET=True)
-        structure = parser.get_structure("structure", BytesIO(raw))
+        with att.path.open("rb") as handle:
+            structure = parser.get_structure("structure", handle)
         chains = []
         for model in structure:
             for chain in model:

--- a/GAIA_agent_design/agents_lib/processors/pdf_processor.py
+++ b/GAIA_agent_design/agents_lib/processors/pdf_processor.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from io import BytesIO
 from typing import List
+
+from ..file_router import Attachment
 
 import pdfplumber
 from pdf2image import convert_from_bytes
@@ -12,16 +13,16 @@ from .image_ocr_agent import call_ocr_api, call_vision_api, preprocess_image
 class PDFProcessorAgent:
     """Extract text from PDF documents."""
 
-    def process(self, raw: bytes, mime_type: str) -> str:
-        file_like = BytesIO(raw)
+    def process(self, att: Attachment) -> str:
+        """Extract text from a PDF file."""
         text_parts: List[str] = []
-        with pdfplumber.open(file_like) as pdf:
+        with pdfplumber.open(att.path) as pdf:
             for page in pdf.pages:
                 text = page.extract_text() or ""
                 text_parts.append(text)
 
         if not any(text_parts):
-            images = convert_from_bytes(raw)
+            images = convert_from_bytes(att.bytes)
             for img in images:
                 try:
                     text_parts.append(call_vision_api(img))

--- a/GAIA_agent_design/agents_lib/processors/pdf_vision_agent.py
+++ b/GAIA_agent_design/agents_lib/processors/pdf_vision_agent.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from hashlib import sha1
 from typing import Dict
 
+from ..file_router import Attachment
+
 from .vision_utils import process_pdf_bytes
 
 DEFAULT_PROMPT = "Extract any text from this image and describe all contents in detail."
@@ -15,10 +17,10 @@ class PDFVisionAgent:
         self.prompt = prompt
         self._cache: Dict[str, str] = {}
 
-    def process(self, raw: bytes, mime_type: str) -> str:
-        key = sha1(raw).hexdigest()
+    def process(self, att: Attachment) -> str:
+        key = sha1(att.bytes).hexdigest()
         if key in self._cache:
             return self._cache[key]
-        text = process_pdf_bytes(raw, self.prompt)
+        text = process_pdf_bytes(att.bytes, self.prompt)
         self._cache[key] = text
         return text

--- a/GAIA_agent_design/agents_lib/processors/pptx_processor.py
+++ b/GAIA_agent_design/agents_lib/processors/pptx_processor.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-from io import BytesIO
 from pptx import Presentation
+
+from ..file_router import Attachment
 
 
 class PPTXProcessorAgent:
     """Extract text from PowerPoint presentations."""
 
-    def process(self, raw: bytes, mime_type: str) -> str:
-        pres = Presentation(BytesIO(raw))
+    def process(self, att: Attachment) -> str:
+        pres = Presentation(att.path)
         texts = []
         for slide in pres.slides:
             for shape in slide.shapes:

--- a/GAIA_agent_design/agents_lib/processors/processor_utils.py
+++ b/GAIA_agent_design/agents_lib/processors/processor_utils.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 from typing import Dict, Protocol
 from ..file_router import Attachment
 
+
+class FileProcessor(Protocol):
+    """Protocol for processor classes."""
+
+    def process(self, att: Attachment) -> str:
+        ...
+
 """Utilities for choosing the right processor for a given MIME type."""
 
 from .text_processor import TextProcessorAgent

--- a/GAIA_agent_design/agents_lib/processors/text_processor.py
+++ b/GAIA_agent_design/agents_lib/processors/text_processor.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import json
 from typing import Tuple
 
+from ..file_router import Attachment
+
 
 class TextProcessorAgent:
     """Process plain text, JSON, or Python source files."""
 
-    def process(self, raw: bytes, mime_type: str) -> str:
+    def process(self, att: Attachment) -> str:
         """Return decoded text for text-like mime types."""
+        raw = att.bytes
+        mime_type = att.mime
         if mime_type.startswith("text/") or "json" in mime_type or "python" in mime_type:
             text = raw.decode("utf-8", errors="ignore")
             # pretty print JSON if possible

--- a/GAIA_agent_design/agents_lib/processors/zip_processor.py
+++ b/GAIA_agent_design/agents_lib/processors/zip_processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from io import BytesIO
 from zipfile import ZipFile
+from pathlib import Path
 import logging
 import mimetypes
 
@@ -10,6 +11,7 @@ try:
 except Exception:  # pragma: no cover - optional dependency may be missing
     magic = None
 
+from ..file_router import Attachment
 from .processor_utils import choose_processor
 
 
@@ -28,8 +30,8 @@ class ZipProcessorAgent:
         else:
             self._magic = None
 
-    def process(self, raw: bytes, mime_type: str) -> str:
-        buf = BytesIO(raw)
+    def process(self, att: Attachment) -> str:
+        buf = BytesIO(att.bytes)
         texts = []
         with ZipFile(buf) as z:
             for name in z.namelist():
@@ -45,8 +47,9 @@ class ZipProcessorAgent:
                 if not mime:
                     mime, _ = mimetypes.guess_type(name)
                 processor = choose_processor(mime or "application/octet-stream")
+                att_inner = Attachment(path=Path(name), data=data, mime=mime or "application/octet-stream")
                 try:
-                    text = processor.process(data, mime or "application/octet-stream")
+                    text = processor.process(att_inner)
                 except Exception as e:
                     self.logger.warning("Failed processing %s: %s", name, e)
                     snippet = data[: self.MAX_BYTES]

--- a/GAIA_agent_design/run_gaia_manager.py
+++ b/GAIA_agent_design/run_gaia_manager.py
@@ -35,7 +35,7 @@ async def main(jsonl_path: str, out_base: str, runs: int) -> None:
         out_path = parent / f"{stem}_{i}.jsonl"
         print(f"[Run {i}/{runs}] Writing to {out_path}")
         tasks.append(asyncio.create_task(manager.run(jsonl_path, str(out_path))))
-        await manager.run(jsonl_path, str(out_path))
+
     await asyncio.gather(*tasks)
 
 


### PR DESCRIPTION
## Summary
- fix `run_gaia_manager.py` so each run executes once
- update all processors to accept an `Attachment` object instead of raw bytes
- add `FileProcessor` protocol to document new interface
- update zip handling to wrap entries as attachments

## Testing
- `python -m compileall -q GAIA_agent_design`

------
https://chatgpt.com/codex/tasks/task_e_6862dcd698ac8333acd281954febbdae