### PR TITLE
Add audio transcription tool using openai-agents voice

### DIFF
--- a/GAIA_agent_design/agents_lib/processors/audio_stt_agent.py
+++ b/GAIA_agent_design/agents_lib/processors/audio_stt_agent.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from hashlib import sha1
 from typing import Dict
 
-import openai
+import numpy as np
+from pydub import AudioSegment
+from agents.voice import AudioInput, OpenAIVoiceModelProvider, STTModelSettings
 
 from ..file_router import Attachment
 
@@ -11,22 +13,49 @@ __all__ = ["AudioSTTAgent"]
 
 
 class AudioSTTAgent:
-    def __init__(self, model: str = "gpt-4o-audio-preview-2025-06-03") -> None:
+    """Transcribe audio files to text using the OpenAI Agents voice stack."""
+
+    def __init__(self, model: str = "gpt-4o-transcribe") -> None:
         self.model = model
+        self._provider = OpenAIVoiceModelProvider()
         self._cache: Dict[str, str] = {}
 
-    def process(self, att: Attachment) -> str:
+    def _prepare_audio(self, att: Attachment) -> AudioInput:
+        if att.path.exists():
+            seg = AudioSegment.from_file(att.path)
+        else:
+            from io import BytesIO
+
+            seg = AudioSegment.from_file(BytesIO(att.bytes))
+
+        seg = seg.set_frame_rate(24000).set_channels(1).set_sample_width(2)
+        buffer = np.array(seg.get_array_of_samples(), dtype=np.int16)
+        return AudioInput(
+            buffer=buffer,
+            frame_rate=seg.frame_rate,
+            sample_width=seg.sample_width,
+            channels=seg.channels,
+        )
+
+    async def async_process(self, att: Attachment) -> str:
         key = sha1(att.bytes).hexdigest()
         if key in self._cache:
             return self._cache[key]
 
-        if att.path.exists():
-            with att.path.open("rb") as f:
-                resp = openai.Audio.transcribe(self.model, f)
-        else:
-            from io import BytesIO
-
-            resp = openai.Audio.transcribe(self.model, BytesIO(att.bytes))
-        text = resp["text"].strip()
+        audio_input = self._prepare_audio(att)
+        model = self._provider.get_stt_model(self.model)
+        text = await model.transcribe(
+            audio_input,
+            STTModelSettings(),
+            trace_include_sensitive_data=False,
+            trace_include_sensitive_audio_data=False,
+        )
+        text = text.strip()
         self._cache[key] = text
         return text
+
+    def process(self, att: Attachment) -> str:
+        """Synchronous wrapper around :meth:`async_process`."""
+        import asyncio
+
+        return asyncio.run(self.async_process(att))

--- a/GAIA_agent_design/agents_lib/tools/__init__.py
+++ b/GAIA_agent_design/agents_lib/tools/__init__.py
@@ -6,6 +6,7 @@ from .file_search_tool import get_file_search_tool
 from .hosted_mcp_tool import get_hosted_mcp_tool
 from .image_gen_tool import get_image_generation_tool
 from .web_search_tool import get_web_search_tool
+from .audio_transcription_tool import transcribe_audio
 from .sandbox import run_python
 
 __all__ = [
@@ -16,5 +17,6 @@ __all__ = [
     "get_hosted_mcp_tool",
     "get_image_generation_tool",
     "get_web_search_tool",
+    "transcribe_audio",
     "run_python",
 ]

--- a/GAIA_agent_design/agents_lib/tools/audio_transcription_tool.py
+++ b/GAIA_agent_design/agents_lib/tools/audio_transcription_tool.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+import mimetypes
+from typing import Optional
+
+from agents import function_tool
+
+from ..file_router import Attachment
+from ..processors.audio_stt_agent import AudioSTTAgent
+
+_transcriber = AudioSTTAgent()
+
+@function_tool
+async def transcribe_audio(file_path: str) -> str:
+    """Transcribe the given audio file to text."""
+    path = Path(file_path)
+    mime = mimetypes.guess_type(path.name)[0] or "audio/wav"
+    att = Attachment(path=path, mime=mime)
+    return await _transcriber.async_process(att)

--- a/GAIA_agent_design/research_bot/agents/planner_agent.py
+++ b/GAIA_agent_design/research_bot/agents/planner_agent.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 
 from agents import Agent
+from ...agents_lib.tools import transcribe_audio
 
 PROMPT = (
     "You are a helpful research assistant. You will be given a question "
@@ -34,4 +35,5 @@ planner_agent = Agent(
     instructions=PROMPT,
     model="o4-mini",
     output_type=SearchPlan,
+    tools=[transcribe_audio],
 )


### PR DESCRIPTION
## Summary
- refactor `AudioSTTAgent` to use the OpenAI Agents voice stack
- expose a `transcribe_audio` function tool for audio transcription
- include the new tool in the agents library exports
- let `planner_agent` access the transcription tool

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686305707dc4833398704e22563c32d3