### PR TITLE
Introduce Azure evaluation tool and enforce verifier usage

### DIFF
--- a/GAIA_agent_design/agents_lib/tools/__init__.py
+++ b/GAIA_agent_design/agents_lib/tools/__init__.py
@@ -8,6 +8,12 @@ from .image_gen_tool import get_image_generation_tool
 from .web_search_tool import get_web_search_tool
 from .audio_transcription_tool import transcribe_audio
 from .sandbox import run_python
+from .azure_evaluation_tool import (
+    azure_task_adherence,
+    VerificationResult,
+    Message,
+    MessageContent,
+)
 
 __all__ = [
     "get_code_interpreter_tool",
@@ -19,4 +25,8 @@ __all__ = [
     "get_web_search_tool",
     "transcribe_audio",
     "run_python",
+    "azure_task_adherence",
+    "VerificationResult",
+    "Message",
+    "MessageContent",
 ]

--- a/GAIA_agent_design/agents_lib/tools/azure_evaluation_tool.py
+++ b/GAIA_agent_design/agents_lib/tools/azure_evaluation_tool.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import json
+from typing import List, Optional
+
+from pydantic import BaseModel
+from agents import function_tool
+from azure.ai.evaluation import TaskAdherenceEvaluator
+from azure.ai.evaluation._model_configurations import OpenAIModelConfiguration
+
+__all__ = [
+    "MessageContent",
+    "Message",
+    "VerificationResult",
+    "azure_task_adherence",
+]
+
+_oai_model_config = OpenAIModelConfiguration(
+    api_key=os.getenv("OPENAI_API_KEY"),
+    base_url="https://api.openai.com/v1",
+    model="o4-mini",
+    type="openai",
+)
+
+_evaluator = TaskAdherenceEvaluator(
+    model_config=_oai_model_config,
+    is_reasoning_model=True,
+)
+
+
+class MessageContent(BaseModel):
+    type: str
+    text: str
+
+
+class Message(BaseModel):
+    role: str
+    content: List[MessageContent]
+
+
+class VerificationResult(BaseModel):
+    score: int
+    feedback: str
+    is_correct: bool
+
+
+@function_tool
+async def azure_task_adherence(
+    query: List[Message],
+    response: List[Message],
+    tool_definitions: Optional[str] = None,
+) -> VerificationResult:
+    """Run Azure Task Adherence evaluator and return a score and feedback."""
+    result = await asyncio.to_thread(
+        _evaluator,
+        query=[m.model_dump() for m in query],
+        response=[m.model_dump() for m in response],
+        tool_definitions=None if tool_definitions is None else json.loads(tool_definitions),
+    )
+    score = result.get("task_adherence_score", 0)
+    feedback = result.get("task_adherence_reason", "")
+    return VerificationResult(score=score, feedback=feedback, is_correct=score >= 3)

--- a/GAIA_agent_design/research_bot/agents/verifier_agent.py
+++ b/GAIA_agent_design/research_bot/agents/verifier_agent.py
@@ -1,99 +1,18 @@
-# from pydantic import BaseModel
-
-# from agents import Agent
-
-# # Agent that double-checks the writer's final answer.
-# # It ensures the answer obeys the question requirements
-# # such as units, rounding, and general correctness.
-# VERIFIER_PROMPT = """
-# You are a careful verifier. You will be given the original question, the writer's reasoning trace, and the final answer. You must confirm whether the answer satisfies the question in every respect:
-
-# - **Units and Format:** Check that the answer is in the exact units, case, and format requested in the question (e.g., “thousand hours” means the answer should be a count in thousands, not the full number; case sensitivity should match the reference).
-# - **Rounding:** Ensure that rounding is performed at the correct step as specified in the instructions. Early or late rounding (compared to the reference solution) that leads to incorrect results should be flagged.
-# - **Final Answer Format:** Make sure the final answer is **not** prefixed by extra text (e.g., “FINAL ANSWER: xxx” should just be "xxx"). Remove any unnecessary labels or whitespace and match the reference answer format exactly.
-# - **Empty or Noncommittal Answers:** If the final answer is “None,” “Not available,” “N/A,” etc., this is incorrect and must be flagged as such.
-# - **Case Sensitivity:** Ensure the case of the final answer exactly matches what the question requests or what is found in the reference (e.g., word is case-sensitive unless the question or reference allows both).
-# - **General Thoroughness:** If there is any deviation from what is requested (format, case, units, rounding, calculation, or completeness), set is_correct to false and clearly explain the specific issue.
-
-# **Instructions for output:**  
-# - Output a JSON dictionary with the fields:  
-#   - `"is_correct"`: (true or false)
-#   - `"feedback"`: (a short explanation of your judgment, explicitly stating any mismatches, including unit, format, rounding, case, missing answers, or calculation errors).
-
-# **Always** review: units, rounding, case, format, completeness, and early/late rounding or calculation mistakes. Be strict; if any detail is off, flag it.
-# """
-
-
-# class VerificationResult(BaseModel):
-#     is_correct: bool
-#     """Whether the answer appears correct and well formatted."""
-
-#     feedback: str
-#     """If not correct, describe the problems."""
-
-
-# verifier_agent = Agent(
-#     name="VerifierAgent",
-#     instructions=VERIFIER_PROMPT,
-#     model="o3",
-#     output_type=VerificationResult,
-# )
-
-# Use Azure AI Evaluation Toolkit: TaskAdherenceEvaluator Class
 from __future__ import annotations
 
-import os, asyncio
-from typing import List, Optional
 from agents import Agent
-from pydantic import BaseModel
-from azure.ai.evaluation import TaskAdherenceEvaluator
-from azure.ai.evaluation._model_configurations import OpenAIModelConfiguration
+from agents.model_settings import ModelSettings
 
-
+from ...agents_lib.tools import azure_task_adherence, VerificationResult
 
 __all__ = ["VerificationResult", "verifier_agent"]
 
-oai_model_config = OpenAIModelConfiguration(
-  api_key = os.getenv("OPENAI_API_KEY"),
-  base_url = "https://api.openai.com/v1",
-  model = "o4-mini",
-  type = "openai",
-)
-
-task_adherence_evaluator = TaskAdherenceEvaluator(
-  model_config=oai_model_config,
-  is_reasoning_model=True,
-)
-
-class VerificationResult(BaseModel):
-  score: int
-  feedback: str
-  is_correct:bool
-
-
-async def _verify_with_azure(
-    query: List[dict],
-    response: List[dict],
-    tool_definitions: Optional[List[dict]] = None,
-) -> VerificationResult:
-    """Run the Azure Task Adherence evaluator and return a simplified result."""
-    result = await asyncio.tothread(
-      task_adherence_evaluator,
-        query=query,
-        response=response,
-        tool_definitions=tool_definitions,
-    )
-
-    score = result.get("task_adherence_score", 0)
-    feedback = result.get("task_adherence_reason", "")
-    is_correct = score >= 3
-    return VerificationResult(is_correct=is_correct, score=score, feedback=feedback)
-
 verifier_agent = Agent(
-  name="VerifierAgent",
-  instructions="Call the verifier_agent function and return results",
-  model="gpt-4o-mini",                
-  output_type=VerificationResult,
-  callable_fn=_verify_with_azure, 
+    name="VerifierAgent",
+    instructions="Use the azure_task_adherence tool to judge the response.",
+    tools=[azure_task_adherence],
+    model="gpt-4o-mini",
+    model_settings=ModelSettings(tool_choice="required"),
+    tool_use_behavior="stop_on_first_tool",
+    output_type=VerificationResult,
 )
-

--- a/GAIA_agent_design/research_bot/manager.py
+++ b/GAIA_agent_design/research_bot/manager.py
@@ -23,6 +23,7 @@ from .agents import (
     AnswerData,
     VerificationResult,
 )
+from ..agents_lib.tools import Message, MessageContent
 
 
 class GAIAResearchManager:
@@ -162,24 +163,24 @@ class GAIAResearchManager:
         )
 
         query = [
-            {"role": "system", "content": PROMPT},
-            {"role": "user", "content": [{"type": "text", "text": question}]},
+            Message(role="system", content=[MessageContent(type="text", text=PROMPT)]),
+            Message(role="user", content=[MessageContent(type="text", text=question)]),
         ]
         response = [
-            {
-                "role": "writer agent",
-                "content": [
-                    {"type": "text", "text": data.reasoning},
-                    {"type": "text", "text": data.answer},
+            Message(
+                role="writer agent",
+                content=[
+                    MessageContent(type="text", text=data.reasoning),
+                    MessageContent(type="text", text=data.answer),
                 ],
-            }
+            )
         ]
         
         result = await Runner.run(
             verifier_agent,
             {"query": query, "response": response, "tool_definitions": None},
         )
-        return result.final_output
+        return result.final_output_as(VerificationResult)
 
     def _format_issue(self, feedback: str) -> bool:
         """Return True if the verifier feedback looks like a formatting issue."""


### PR DESCRIPTION
## Summary
- add `azure_task_adherence` tool that wraps Azure AI Evaluation
- export the tool along with helper message models
- rewrite `verifier_agent` to call this tool via OpenAI Agents
- adapt `manager` to use structured message models

## Testing
- `python -m py_compile GAIA_agent_design/agents_lib/tools/azure_evaluation_tool.py GAIA_agent_design/research_bot/agents/verifier_agent.py GAIA_agent_design/research_bot/manager.py`
- `python -m compileall -q GAIA_agent_design`
- `python GAIA_agent_design/run_gaia_manager.py GAIA_agent_design/small_batch.jsonl test_out.jsonl 1` *(fails: ModuleNotFoundError: No module named 'docx')*


------
https://chatgpt.com/codex/tasks/task_e_68645411a840833383309958185f04ef