### PR TITLE
Fix GAIA manager concurrency

### DIFF
--- a/GAIA_agent_design/research_bot/manager.py
+++ b/GAIA_agent_design/research_bot/manager.py
@@ -27,9 +27,15 @@ from ..agents_lib.tools import Message, MessageContent
 
 
 class GAIAResearchManager:
-    def __init__(self, media_dir: Path) -> None:
+    def __init__(self, media_dir: Path, *, max_concurrency: int = 20) -> None:
         self.media_dir = media_dir
         self.file_router = FileRouterAgent(media_dir)
+        self._sem = asyncio.Semaphore(max_concurrency)
+
+    async def _run_limited(self, agent, prompt: str):
+        """Run an agent call while respecting the concurrency limit."""
+        async with self._sem:
+            return await Runner.run(agent, prompt)
 
     async def run(self, jsonl_path: str, out_path: str) -> None:
         """Process all tasks in ``jsonl_path`` concurrently and write results."""
@@ -99,7 +105,7 @@ class GAIAResearchManager:
 
     async def _plan_searches(self, question: str, context: str) -> SearchPlan:
         prompt = f"Question: {question}\nContext:\n{context}"
-        result = await Runner.run(planner_agent, prompt)
+        result = await self._run_limited(planner_agent, prompt)
         return result.final_output_as(SearchPlan)
 
     async def _perform_searches(self, plan: SearchPlan, context: str) -> list[str]:
@@ -119,7 +125,7 @@ class GAIAResearchManager:
             f"\nContext:\n{context}"
         )
         try:
-            result = await Runner.run(search_agent, prompt)
+            result = await self._run_limited(search_agent, prompt)
             return str(result.final_output)
         except Exception:
             return None
@@ -130,7 +136,7 @@ class GAIAResearchManager:
         prompt = f"Question: {question}\nCurrent summaries: {summaries}"
         if feedback:
             prompt += f"\nVerifier feedback: {feedback}"
-        result = await Runner.run(evaluator_agent, prompt)
+        result = await self._run_limited(evaluator_agent, prompt)
         return result.final_output_as(SearchPlan)
 
     async def _write_answer(
@@ -145,7 +151,7 @@ class GAIAResearchManager:
         )
         if feedback:
             input += f"\nVerifier feedback: {feedback}\nPlease correct your answer accordingly."
-        result = await Runner.run(writer_agent, input)
+        result = await self._run_limited(writer_agent, input)
         return result.final_output_as(AnswerData)
 
     async def _verify_answer(
@@ -185,7 +191,7 @@ class GAIAResearchManager:
             }
         )
 
-        result = await Runner.run(verifier_agent, verifier_input)
+        result = await self._run_limited(verifier_agent, verifier_input)
         return result.final_output_as(VerificationResult)
         
     def _format_issue(self, feedback: str) -> bool:

--- a/GAIA_agent_design/run_gaia_manager.py
+++ b/GAIA_agent_design/run_gaia_manager.py
@@ -17,13 +17,13 @@ logfire.instrument_httpx()
 logfire.instrument_openai_agents()
 
 
-async def main(jsonl_path: str, out_base: str, runs: int) -> None:
+async def main(jsonl_path: str, out_base: str, runs: int, max_concurrency: int) -> None:
     """
     Run the GAIAResearchManager `runs` times, writing each submission to
     out_base_1.jsonl, out_base_2.jsonl, ..., out_base_N.jsonl
     """
     media_dir = Path("GAIA_agent_design/gaia_media").resolve()
-    manager = GAIAResearchManager(media_dir)
+    manager = GAIAResearchManager(media_dir, max_concurrency=max_concurrency)
 
     # strip any extension from the base, to avoid double ".jsonl.jsonl"
     base = Path(out_base)
@@ -40,15 +40,28 @@ async def main(jsonl_path: str, out_base: str, runs: int) -> None:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) not in (4,):
-        print("Usage: python run_gaia_manager.py <metadata.jsonl> <submission_base.jsonl> <num_runs>")
-        print("Example: python run_gaia_manager.py metadata.jsonl my_submission.jsonl 5")
+    if len(sys.argv) not in (4, 5):
+        print(
+            "Usage: python run_gaia_manager.py <metadata.jsonl> <submission_base.jsonl> <num_runs> [max_concurrency]"
+        )
+        print(
+            "Example: python run_gaia_manager.py metadata.jsonl my_submission.jsonl 5 20"
+        )
         raise SystemExit(1)
-    _, metadata, submission_base, runs_str = sys.argv
+    _, metadata, submission_base, runs_str, *extra = sys.argv
     try:
         runs = int(runs_str)
     except ValueError:
         print(f"Invalid run count: {runs_str}")
         raise SystemExit(1)
 
-    asyncio.run(main(metadata, submission_base, runs))
+    if extra:
+        try:
+            concurrency = int(extra[0])
+        except ValueError:
+            print(f"Invalid concurrency: {extra[0]}")
+            raise SystemExit(1)
+    else:
+        concurrency = 20
+
+    asyncio.run(main(metadata, submission_base, runs, concurrency))


### PR DESCRIPTION
## Summary
- limit concurrent agent calls in `GAIAResearchManager` with a semaphore
- expose an optional `max_concurrency` argument on `run_gaia_manager.py`

## Testing
- `python -m py_compile GAIA_agent_design/run_gaia_manager.py GAIA_agent_design/research_bot/manager.py`

------
https://chatgpt.com/codex/tasks/task_e_686562dfb218833380d9447330d30bf2